### PR TITLE
Add Topic Diary System

### DIFF
--- a/Feature/Topic-Diary-System/README.md
+++ b/Feature/Topic-Diary-System/README.md
@@ -1,0 +1,124 @@
+# Topic Diary System
+*Topic-based memory journals for discoveries, fixes, and reusable knowledge*
+
+## What This Feature Does
+
+Adds a structured topic diary system to your AI companion, enabling **knowledge-by-topic documentation** that captures discoveries, fixes, commands, lessons, and decisions across many sessions.
+
+- **Topic-based journals** in `topic-diary/topics/` instead of only date-based diary files
+- **Append-only entries** for each topic, preserving chronological learning history
+- **Topic index** in `topic-diary/index.md` for quick scanning and recall
+- **Save routing** for ambiguous `save` requests: session memory, daily diary, topic diary, or multiple targets
+- **Skill auto-install** if Skill Plugin System is detected
+
+## How It Works
+
+### The Concept
+
+Daily Diary answers: **What happened today?**
+
+Topic Diary answers: **What have we learned about this subject over time?**
+
+The system turns repeated discoveries into living notebooks. Instead of losing Docker fixes, project setup details, debugging patterns, or research insights inside dated session entries, your AI appends them to a focused topic file.
+
+### Example: Saving a Technical Discovery
+
+```text
+You: "save this"
+AI: "Save where: session, daily diary, topic diary, or all? I detected topic: docker."
+You: "topic diary"
+AI:
+  1. Creates or opens topic-diary/topics/docker.md
+  2. Appends a timestamped entry with the confirmed command, root cause, and lesson
+  3. Updates topic-diary/index.md with docker keywords and latest update
+  4. Confirms the save target and topic
+```
+
+### How It Differs From Daily Diary
+
+| Aspect | Daily Diary | Topic Diary |
+|--------|-------------|-------------|
+| **Primary question** | What happened today? | What have we learned about this topic? |
+| **Organization** | By date | By subject |
+| **Best for** | Session story, achievements, collaboration | Reusable knowledge, fixes, commands, patterns |
+| **Recall path** | Search by date/session | Open one focused topic file |
+| **Examples** | "April 8 session recap" | `docker.md`, `9router.md`, `writing-style.md` |
+
+## Directory Structure
+
+```text
+topic-diary/
+├── index.md                         # Topic catalog and recall map
+├── topics/                          # Active topic journals
+│   ├── docker.md                    # Docker discoveries and fixes
+│   ├── 9router.md                   # 9router setup, patches, troubleshooting
+│   └── writing-style.md             # Preferences and writing patterns
+└── archived/                        # Optional archived topics
+    └── old-project.md
+```
+
+## Quick Integration
+
+```text
+"Load topic-diary"
+```
+
+## What Happens During Integration
+
+1. **Creates** `topic-diary/topics/` and `topic-diary/archived/` directories
+2. **Creates** `topic-diary/index.md` using `index-format.md`
+3. **Adds** topic diary commands and save-routing behavior to `master-memory.md`
+4. **Installs as skill** if Skill Plugin System is detected
+5. **Keeps Daily Diary unchanged** so chronological and topic-based memory can coexist
+
+## Post-Integration Result
+
+After running the integration protocol:
+
+- Your AI can route `save` requests to session memory, daily diary, topic diary, or all targets
+- Every topic save appends to a focused markdown journal
+- The index tracks available topics, aliases, latest updates, and recall keywords
+- Daily Diary remains available for session storytelling
+- Echo Memory Recall can use topic files as high-signal recall sources
+
+## Save Routing
+
+When the user says `save`, `save memory`, or `remember this`, the AI should determine the best save target:
+
+| Target | Use When |
+|--------|----------|
+| **Session memory** | Needed for immediate continuation after restart |
+| **Daily diary** | Captures the story or recap of a session |
+| **Topic diary** | Captures reusable knowledge about a subject |
+| **All** | Important information belongs in multiple memory layers |
+
+If the save target is ambiguous, ask one short question before writing.
+
+## Entry Sections
+
+Each topic entry follows `topic-format.md` and captures:
+
+| Section | What It Captures |
+|---------|------------------|
+| **Context** | Why the topic came up and what was being solved |
+| **Discovery** | What was learned or decided |
+| **Confirmed Details** | Commands, paths, settings, examples, or facts verified in-session |
+| **Pitfalls** | Mistakes, false assumptions, warnings, or edge cases |
+| **Recall Keywords** | Search terms and aliases for future retrieval |
+| **Follow-ups** | Optional next steps or unanswered questions |
+
+## Benefits
+
+- **Faster recall** — recurring subjects have one focused knowledge file
+- **Less noise** — reusable facts do not get buried in date-based diary entries
+- **Better debugging memory** — commands, root causes, and verified fixes stay together
+- **Works with existing MemoryCore** — complements Daily Diary, Session RAM, and Echo Recall
+- **Portable** — plain markdown files, human-readable and AI-readable
+
+## Platform Note
+
+Works with any AI system. Uses plain markdown files and optional shell timestamp commands. Auto-triggered skill requires Claude Code with the Skill Plugin System.
+
+---
+
+*A subject remembers what the calendar forgets.*

--- a/Feature/Topic-Diary-System/SKILL.md
+++ b/Feature/Topic-Diary-System/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: topic-diary
+description: "MUST use when user says 'save topic', 'save to topic diary', 'remember this under', 'review topic', 'list topics', or when a generic 'save' request needs routing between session memory, daily diary, topic diary, or all targets."
+---
+
+# Topic Diary — Subject-Based Memory Skill
+*A subject remembers what the calendar forgets.*
+
+## Activation
+
+When this skill activates for a topic save, output:
+
+```text
+Capturing this under the right topic.
+```
+
+For a generic `save` request, do not write immediately if the target is unclear. Ask one short routing question.
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User says "save topic"** | ACTIVE — topic diary write |
+| **User says "save to topic diary"** | ACTIVE — topic diary write |
+| **User says "remember this under [topic]"** | ACTIVE — named topic write |
+| **User says "review topic [topic]"** | ACTIVE — read and summarize topic |
+| **User says "list topics"** | ACTIVE — read topic index |
+| **User says generic "save"** | ACTIVE — route save target before writing |
+| **No save or recall request** | DORMANT — no topic diary action |
+
+## Save Routing Protocol
+
+When the user says `save`, `save memory`, `remember this`, or another ambiguous save phrase:
+
+1. Infer the likely target from context.
+2. If confidence is high, briefly state the target and proceed.
+3. If unclear, ask:
+
+```text
+Save where: session memory, daily diary, topic diary, or all?
+```
+
+Use these rules:
+
+| Target | Use When |
+|--------|----------|
+| **Session memory** | Needed to continue current work after restart |
+| **Daily diary** | Captures session story, collaboration, or achievements |
+| **Topic diary** | Captures reusable knowledge about a subject |
+| **All** | Information is both immediately important and reusable long-term |
+
+## Topic Save Protocol
+
+### Step 1: Determine Topic
+
+- [ ] Use explicit topic if user says `under [topic]`
+- [ ] Otherwise infer from session context
+- [ ] If uncertain, ask one short question:
+
+```text
+Which topic should I save this under?
+```
+
+### Step 2: Normalize Topic Filename
+
+- [ ] Convert topic to lowercase kebab-case
+- [ ] Remove unsafe path characters
+- [ ] Use `topic-diary/topics/[topic].md`
+- [ ] Examples:
+  - `Docker Compose` -> `docker-compose.md`
+  - `9router Kiro` -> `9router-kiro.md`
+  - `Writing Style` -> `writing-style.md`
+
+### Step 3: Create Topic File If Missing
+
+If the topic file does not exist, create it using `topic-format.md` header structure:
+
+```markdown
+# [Topic Name] Topic Diary
+*Reusable discoveries, fixes, decisions, and lessons for this subject.*
+
+## Topic Metadata
+- **Created**: [date]
+- **Last Updated**: [date]
+- **Aliases**: [related names]
+- **Recall Keywords**: [search terms]
+
+---
+```
+
+### Step 4: Compose Entry
+
+- [ ] Get real timestamp via platform command
+- [ ] Write a concise, evidence-based entry using these sections:
+  - Context
+  - Discovery
+  - Confirmed Details
+  - Pitfalls
+  - Recall Keywords
+  - Follow-ups
+- [ ] Include commands, paths, links, error messages, and decisions when relevant
+- [ ] Avoid raw transcript dumps
+
+### Step 5: Append Entry
+
+- [ ] Append with `---` separator
+- [ ] Never overwrite previous entries
+- [ ] Keep entries concise and high-signal
+
+### Step 6: Update Index
+
+- [ ] Create `topic-diary/index.md` if missing using `index-format.md`
+- [ ] Add topic if new
+- [ ] Update latest date, aliases, and recall keywords
+
+### Step 7: Confirm
+
+Confirm the save target and file:
+
+```text
+Saved to topic diary: topic-diary/topics/[topic].md
+```
+
+## Review Protocol
+
+When user says `review topic [topic]`:
+
+1. Open the matching topic file.
+2. Summarize current understanding.
+3. Highlight confirmed facts, open questions, and latest entries.
+4. Mention the source file path.
+
+## List Protocol
+
+When user says `list topics`:
+
+1. Read `topic-diary/index.md`.
+2. Show topic names, aliases, and latest update.
+3. If the index is missing, scan `topic-diary/topics/` and offer to rebuild it.
+
+## Mandatory Rules
+
+1. **Always append** — never overwrite topic entries
+2. **Ask when ambiguous** — generic `save` must route to the correct memory layer
+3. **Keep memory layers distinct** — session, daily diary, and topic diary have different purposes
+4. **Use real timestamps** — do not invent dates or times
+5. **Prefer evidence** — save verified commands, paths, decisions, and lessons
+6. **Update index** — every topic write should keep recall metadata fresh
+7. **Respect privacy** — do not save sensitive secrets, tokens, or credentials into topic files
+
+## Edge Cases
+
+| Situation | Behavior |
+|-----------|----------|
+| No `topic-diary/` folder | Create required directories first |
+| Topic unclear | Ask for topic name before writing |
+| User says `save all` | Save to all relevant memory layers, if available |
+| Sensitive content detected | Ask before saving or redact secrets |
+| Topic file too large | Suggest archive or split, but do not delete content |
+| Index missing | Recreate from existing topic files |
+
+## Level History
+
+- **Lv.1** — Base: topic-based append-only journals, save target routing, topic index updates, and review/list commands.

--- a/Feature/Topic-Diary-System/index-format.md
+++ b/Feature/Topic-Diary-System/index-format.md
@@ -1,0 +1,48 @@
+# Topic Diary Index Format
+*Canonical format for `topic-diary/index.md`*
+
+Use this format to catalog available topic diaries and make recall easier.
+
+## File Template
+
+```markdown
+# Topic Diary Index
+*Catalog of subject-based memory journals.*
+
+## Active Topics
+
+| Topic | File | Aliases | Recall Keywords | Last Updated |
+|-------|------|---------|-----------------|--------------|
+| Docker | `topics/docker.md` | containers, compose | docker, compose, ports, volumes | YYYY-MM-DD |
+
+## Archived Topics
+
+| Topic | File | Reason Archived | Archived Date |
+|-------|------|-----------------|---------------|
+
+## Save Routing Notes
+
+- **Session memory**: immediate restart continuity
+- **Daily diary**: session story and chronological record
+- **Topic diary**: reusable knowledge organized by subject
+- **All**: important information that belongs in multiple memory layers
+
+## Maintenance Notes
+
+- Add a row when creating a new topic file.
+- Update `Last Updated` whenever a topic receives a new entry.
+- Add aliases that users or AI might naturally use.
+- Keep recall keywords short and search-friendly.
+```
+
+## Index Guidelines
+
+- Keep one row per active topic.
+- Use relative links or file paths that work from `topic-diary/index.md`.
+- Include aliases for alternate spellings, tool names, or project names.
+- Move old topics to the archived table only when the user explicitly archives them.
+- If the index is lost, rebuild it by scanning `topic-diary/topics/*.md`.
+
+---
+
+*The index is the map; topic files are the memory.*

--- a/Feature/Topic-Diary-System/install-topic-diary.md
+++ b/Feature/Topic-Diary-System/install-topic-diary.md
@@ -1,0 +1,113 @@
+# Install Topic Diary System
+*Integration protocol for topic-based memory journals*
+
+## Activation
+
+When the user says `Load topic-diary`, install the Topic Diary System into the active MemoryCore.
+
+## Prerequisites
+
+- Existing MemoryCore root with `master-memory.md`
+- Optional but recommended: Skill Plugin System
+- Optional companion features: Save Diary System and Echo Memory Recall
+
+## Installation Steps
+
+### Step 1: Confirm MemoryCore Root
+
+Locate the active MemoryCore root. It should contain:
+
+```text
+master-memory.md
+main/
+```
+
+If the user's MemoryCore uses customized folder names, ask for confirmation before writing files.
+
+### Step 2: Create Topic Diary Directories
+
+Create these directories if missing:
+
+```text
+topic-diary/
+topic-diary/topics/
+topic-diary/archived/
+```
+
+Never delete or overwrite existing topic files.
+
+### Step 3: Create Topic Index
+
+If `topic-diary/index.md` does not exist, create it using `index-format.md`.
+
+If it exists, append a short installation note instead of replacing it.
+
+### Step 4: Add Master Memory References
+
+Update `master-memory.md` with:
+
+```markdown
+### Topic Diary System
+*Load when user says: "save topic", "save to topic diary", "remember this under [topic]", or when reusable knowledge should be preserved by subject.*
+- Stores long-term knowledge in `topic-diary/topics/[topic].md`
+- Uses `topic-diary/index.md` for topic aliases and recall keywords
+- Complements Daily Diary and Session RAM
+```
+
+Also add save routing guidance:
+
+```markdown
+When user says "save" and the target is unclear, ask whether to save to session memory, daily diary, topic diary, or all relevant targets.
+```
+
+### Step 5: Install Skill Plugin
+
+If Skill Plugin System is installed:
+
+1. Copy `SKILL.md` into the configured skills/plugin folder as `topic-diary/SKILL.md`
+2. Preserve existing skill files
+3. Confirm the trigger phrases are available
+
+If no Skill Plugin System is installed, leave the feature folder in place and record the manual commands in `master-memory.md`.
+
+### Step 6: First Topic Entry
+
+Ask whether the user wants to create a first topic entry.
+
+Suggested prompt:
+
+```text
+Topic Diary is installed. Do you want to create a first topic entry now, or leave it ready for the next save?
+```
+
+## Commands After Installation
+
+| Command | Behavior |
+|---------|----------|
+| `save topic` | Save current reusable knowledge to a topic diary |
+| `save to topic diary` | Ask for or infer topic, then append entry |
+| `remember this under [topic]` | Append to the named topic file |
+| `review topic [topic]` | Read and summarize the topic diary |
+| `list topics` | Show topics from `topic-diary/index.md` |
+| `save` | Ask target if ambiguous: session, daily diary, topic diary, or all |
+
+## Safety Rules
+
+1. **Append only** — never overwrite topic entries
+2. **Ask when ambiguous** — especially for generic `save`
+3. **Keep layers distinct** — session memory is for continuity; diary is for story; topic diary is for reusable knowledge
+4. **Use kebab-case filenames** — `Docker Compose` becomes `docker-compose.md`
+5. **Update the index** after every new or changed topic
+6. **Do not self-delete** this feature folder unless the user explicitly requests cleanup
+
+## Uninstall
+
+To uninstall manually:
+
+1. Remove Topic Diary references from `master-memory.md`
+2. Remove the installed `topic-diary` skill from the plugin folder
+3. Keep `topic-diary/` unless the user explicitly wants to delete saved knowledge
+
+---
+
+*Topic Diary installs as a companion to memory, not a replacement for it.*

--- a/Feature/Topic-Diary-System/topic-format.md
+++ b/Feature/Topic-Diary-System/topic-format.md
@@ -1,0 +1,96 @@
+# Topic Diary Format
+*Canonical format for `topic-diary/topics/[topic].md` files*
+
+Use this format for every topic diary file.
+
+## File Naming
+
+Topic filenames use lowercase kebab-case:
+
+```text
+topic-diary/topics/docker.md
+topic-diary/topics/docker-compose.md
+topic-diary/topics/9router.md
+topic-diary/topics/writing-style.md
+```
+
+## File Template
+
+```markdown
+# [Topic Name] Topic Diary
+*Reusable discoveries, fixes, decisions, and lessons for this subject.*
+
+## Topic Metadata
+- **Created**: YYYY-MM-DD HH:MM
+- **Last Updated**: YYYY-MM-DD HH:MM
+- **Aliases**: [alias 1], [alias 2]
+- **Recall Keywords**: [keyword 1], [keyword 2], [keyword 3]
+
+---
+
+## YYYY-MM-DD HH:MM — [Entry Title]
+
+### Context
+- What prompted this discovery or save?
+- What problem, project, or question was being handled?
+
+### Discovery
+- What did we learn, decide, or confirm?
+- Why does it matter for future sessions?
+
+### Confirmed Details
+- Commands, paths, settings, examples, or facts verified during the session.
+- Include exact errors or outputs when useful.
+
+### Pitfalls
+- Mistakes, false assumptions, warnings, or edge cases to avoid.
+
+### Recall Keywords
+- Keywords and aliases future AI sessions should use to find this entry.
+
+### Follow-ups
+- Optional next steps, unresolved questions, or related topics.
+```
+
+## Entry Guidelines
+
+- Keep entries concise and high-signal.
+- Prefer verified facts over speculation.
+- Include exact commands, paths, and error messages when useful.
+- Do not save secrets, tokens, passwords, or private credentials.
+- Append new entries below older entries, separated by `---`.
+- Update `Last Updated` and recall keywords after each write.
+
+## Good Entry Example
+
+```markdown
+---
+
+## 2026-04-08 14:30 — Docker Compose Port Conflict Fix
+
+### Context
+- Local service failed to start because Docker reported port 3000 was already allocated.
+- User was testing a web app through Docker Compose.
+
+### Discovery
+- The conflict came from an old container still binding port 3000.
+- Removing the stopped container freed the port and allowed the stack to start.
+
+### Confirmed Details
+- `docker ps -a` showed the old container.
+- `docker rm [container]` removed it.
+- `docker compose up -d` started successfully after cleanup.
+
+### Pitfalls
+- `docker compose down` only affects the current compose project. It may not remove unrelated containers using the same port.
+
+### Recall Keywords
+- docker, compose, port conflict, address already in use, container cleanup
+
+### Follow-ups
+- Consider documenting common Docker cleanup commands in a separate Docker topic entry.
+```
+
+---
+
+*A topic diary is a living notebook, not a transcript.*

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Features are organized into **tiers** based on dependencies. Install Tier 1 firs
 | Feature | Description | Setup |
 |---------|-------------|-------|
 | 📖 [Save Diary](Feature/Save-Diary-System/) | Daily session documentation with monthly auto-archival | `"Load save-diary"` |
+| 🗂️ [Topic Diary](Feature/Topic-Diary-System/) | Topic-based memory journals for discoveries, fixes, and lessons across sessions — *pairs well with Save Diary + Echo Recall* | `"Load topic-diary"` |
 | 🔍 [Echo Memory Recall](Feature/Echo-Memory-Recall/) | Search past sessions with narrative context — *requires Save Diary* | `"Load echo-recall"` |
 | 🔔 [Reminders](Feature/Reminders-System/) | Persistent cross-session reminders with deadline tracking | `"Load reminders"` |
 | 📋 [Decision Log](Feature/Decision-Log-System/) | Append-only record of decisions and their reasoning | `"Load decision-log"` |


### PR DESCRIPTION
## Summary
Adds a Topic Diary System for topic-based memory journals.

Unlike Daily Diary, which records chronological session history, Topic Diary organizes discoveries, fixes, lessons, commands, and reusable knowledge by subject. This makes long-term recall easier for recurring topics like Docker, project setup, debugging patterns, personal workflows, or research themes.

## Added
- `Feature/Topic-Diary-System/README.md`
- `Feature/Topic-Diary-System/install-topic-diary.md`
- `Feature/Topic-Diary-System/SKILL.md`
- `Feature/Topic-Diary-System/topic-format.md`
- `Feature/Topic-Diary-System/index-format.md`
- README entry under Tier 2 Memory & Documentation

## Why
Daily diaries answer: What happened today?

Topic diaries answer: What have we learned about this topic over time?

The feature complements Save Diary, Session RAM, and Echo Memory Recall without changing existing daily diary behavior.
