### PR TITLE
Add Memory Compaction System

### DIFF
--- a/Feature/Memory-Compaction-System/README.md
+++ b/Feature/Memory-Compaction-System/README.md
@@ -1,0 +1,95 @@
+# Memory Compaction System
+*Intelligent memory compression that summarizes old entries instead of deleting them*
+
+## What This Feature Does
+
+Adds a **size-aware compaction layer** to your AI companion. When a memory file grows past a configurable budget, the AI **compresses the oldest, lowest-signal entries into a dense summary** — preserving facts, decisions, and preferences while reclaiming space.
+
+- **Budget-aware** — each memory file has a line/character budget (e.g. 500 lines or 8000 chars)
+- **Compress, don't delete** — old entries are summarized into a `## Compacted History` block, not thrown away
+- **Signal-preserving** — verified facts, user preferences, and decisions survive; chatter and redundancy are dropped
+- **Tiered retention** — recent entries stay verbatim, mid-age entries get light summarization, old entries get heavy compaction
+- **Reversible by design** — a pre-compaction snapshot is written to `compaction/snapshots/` before any rewrite
+- **Skill auto-install** if Skill Plugin System is detected
+
+## How It Works
+
+### The Concept
+
+Most memory systems handle growth by **truncation** — when the file gets too big, they delete the oldest content. That loses knowledge permanently.
+
+Memory Compaction takes a different path: when a file exceeds its budget, the AI **reads the oldest entries, distills them into a concise summary, and replaces the verbose originals with that summary**. The file stays small, but the knowledge survives.
+
+Think of it like a journal you periodically rewrite — keeping the lessons, dropping the noise.
+
+### Example: A Memory File Hits Its Budget
+
+```text
+You: "save this"
+AI: "Memory file is at 512/500 lines. Compacting oldest entries before saving."
+AI:
+  1. Snapshots the current file to compaction/snapshots/main-memory-2026-06-06.md
+  2. Reads the oldest 30% of entries
+  3. Summarizes them into a dense "Compacted History" block (facts + decisions preserved)
+  4. Replaces the verbose originals with the summary
+  5. Appends the new save
+  6. Confirms: "Compacted 47 lines into 9. File now 474/500 lines."
+```
+
+### How It Differs From Existing Features
+
+| Aspect | Memory Consolidation | Session Memory Limit | Memory Compaction |
+|--------|----------------------|----------------------|-------------------|
+| **Purpose** | Merge split files into one | Cap session RAM size | Keep growing files within budget |
+| **Method** | Structural merge | Hard reset, preserve recap | Summarize old entries, preserve knowledge |
+| **On overflow** | N/A (one-time upgrade) | Delete detail, keep recap | Compress detail into summary |
+| **Knowledge loss** | None (merge) | High (detail discarded) | Minimal (summarized, snapshotted) |
+| **Runs** | Once (architecture upgrade) | Every session reset | Continuously, when budget exceeded |
+
+> **Companion, not replacement.** Memory Consolidation unifies *which* files exist. Session Memory Limit caps *session RAM*. Memory Compaction keeps *long-lived files* (main memory, relationship memory, topic diaries) within budget without losing what they learned.
+
+## Directory Structure
+
+```text
+compaction/
+├── compaction-policy.md             # Active budgets and retention tiers
+└── snapshots/                       # Pre-compaction backups (reversible)
+    └── main-memory-2026-06-06.md
+```
+
+## Quick Integration
+
+```text
+"Load memory-compaction"
+```
+
+## What Happens During Integration
+
+1. **Creates** `compaction/` and `compaction/snapshots/` directories
+2. **Creates** `compaction/compaction-policy.md` using `policy-format.md`
+3. **Adds** compaction triggers and budget-check behavior to `master-memory.md`
+4. **Installs as skill** if Skill Plugin System is detected
+5. **Touches no content yet** — first compaction only runs when a file actually exceeds budget
+
+## Post-Integration Result
+
+After running the integration protocol:
+
+- Every long-lived memory file has a defined budget
+- Before each `save`, the AI checks whether the target file is over budget
+- When over budget, the AI snapshots, compacts the oldest tier, then saves
+- A `## Compacted History` block preserves distilled knowledge from old entries
+- You can always recover the pre-compaction state from `compaction/snapshots/`
+
+## Safety Rules
+
+1. **Snapshot before compaction** — never rewrite a file without a backup
+2. **Never compact the newest tier** — recent context stays verbatim
+3. **Preserve all facts, decisions, and preferences** — only redundancy and chatter are dropped
+4. **Never compact secrets** — tokens, passwords, and credentials are excluded, never summarized into shared blocks
+5. **Confirm before first compaction** of any file if the user has customized it
+6. **Do not self-delete** this feature folder unless the user explicitly requests cleanup
+
+---
+
+*Compaction keeps memory small without making it forget.*

--- a/Feature/Memory-Compaction-System/SKILL.md
+++ b/Feature/Memory-Compaction-System/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: memory-compaction
+description: "MUST use when user says 'compact memory', 'compact [file]', 'check budgets', 'set budget', 'restore compaction', or before any 'save' whose target memory file exceeds its budget in compaction/compaction-policy.md."
+---
+
+# Memory Compaction — Budget-Aware Memory Skill
+*Keep memory small without making it forget.*
+
+## Activation
+
+When this skill activates for a compaction pass, output:
+
+```text
+Checking memory budgets before saving.
+```
+
+Never rewrite a memory file without first writing a snapshot.
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User says "compact memory"** | ACTIVE — compact all over-budget files |
+| **User says "compact [file]"** | ACTIVE — compact one file |
+| **User says "check budgets"** | ACTIVE — report sizes vs budgets |
+| **User says "set budget ..."** | ACTIVE — update policy |
+| **User says "restore compaction ..."** | ACTIVE — roll back from snapshot |
+| **Generic "save" on a budgeted file over budget** | ACTIVE — compact then save |
+| **Save on a file under budget** | DORMANT — save normally |
+| **No save or compaction request** | DORMANT — no action |
+
+## Budget Check Protocol
+
+Before writing any `save` to a budgeted file:
+
+1. Read `compaction/compaction-policy.md` for the file's budget and newest-tier size.
+2. Measure the current file (lines or chars per the policy unit).
+3. If under budget → save normally, no compaction.
+4. If over budget → run the Compaction Protocol below, then save.
+
+## Compaction Protocol
+
+### Step 1: Snapshot
+
+- [ ] Run `date` to get the current timestamp.
+- [ ] Copy the target file to `compaction/snapshots/[file]-[YYYY-MM-DD].md`.
+- [ ] If a snapshot for today exists, append `-HHMM` to avoid overwriting.
+
+### Step 2: Split Into Tiers
+
+- [ ] **Newest tier** — the last N entries per the policy. Never touched.
+- [ ] **Mid-age tier** — entries between newest and oldest. Light summarization only.
+- [ ] **Oldest tier** — everything older. Target for heavy compaction.
+
+### Step 3: Compact the Oldest Tier
+
+- [ ] Read every entry in the oldest tier.
+- [ ] Distill into a dense summary that keeps:
+  - Verified facts, paths, commands, and settings
+  - Decisions and the reasons behind them
+  - User preferences and recurring corrections
+- [ ] Drop:
+  - Redundant or duplicated statements
+  - Resolved chatter and one-off context
+  - Filler and transitional notes
+- [ ] **Never** include secrets, tokens, passwords, or credentials in the summary.
+
+### Step 4: Rewrite
+
+- [ ] Replace the verbose oldest-tier entries with a single block:
+
+```markdown
+## Compacted History
+*Distilled from [N] entries on [YYYY-MM-DD]. Full detail in compaction/snapshots/[file]-[date].md.*
+
+- [fact / decision / preference, one dense bullet each]
+```
+
+- [ ] Keep the mid-age and newest tiers in place.
+- [ ] Append the new save below.
+
+### Step 5: Verify and Report
+
+- [ ] Confirm the file is now under budget.
+- [ ] Confirm no fact, decision, or preference was lost (compare against snapshot if unsure).
+- [ ] Report:
+
+```text
+Compacted [N] entries ([X] lines) into a [Y]-line history block.
+[file] is now [Z]/[budget] lines. Snapshot: compaction/snapshots/[file]-[date].md
+```
+
+## Restore Protocol
+
+When the user says `restore compaction [snapshot]`:
+
+1. Confirm the snapshot exists in `compaction/snapshots/`.
+2. Show the user the snapshot date and size.
+3. Ask for confirmation before overwriting the current file.
+4. Replace the current file with the snapshot contents.
+
+## Safety Rules
+
+1. **Snapshot before every compaction** — no exceptions.
+2. **Never compact the newest tier.**
+3. **Preserve all facts, decisions, and preferences.**
+4. **Never summarize secrets** into a shared `Compacted History` block.
+5. **Confirm before first compaction** of a user-customized file.
+6. **Compaction is summarization, not deletion** — knowledge moves to a denser form, it does not disappear.
+
+---
+
+*A good compaction is one the user never notices, except that memory stopped overflowing.*

--- a/Feature/Memory-Compaction-System/SKILL.md
+++ b/Feature/Memory-Compaction-System/SKILL.md
@@ -43,14 +43,23 @@ Before writing any `save` to a budgeted file:
 ### Step 1: Snapshot
 
 - [ ] Run `date` to get the current timestamp.
-- [ ] Copy the target file to `compaction/snapshots/[file]-[YYYY-MM-DD].md`.
-- [ ] If a snapshot for today exists, append `-HHMM` to avoid overwriting.
+- [ ] Copy the target file to `compaction/snapshots/[basename]-[YYYY-MM-DD].md`
+      (use only the filename without its directory — e.g. `main-memory`, not `main/main-memory` —
+      so snapshots never create nested subdirectories inside `compaction/snapshots/`).
+- [ ] If a snapshot for today already exists, append `-HHMMSS` (seconds included) to avoid
+      overwriting. If a same-second collision is still possible, use a sequential suffix
+      (`-v2`, `-v3`).
 
 ### Step 2: Split Into Tiers
 
 - [ ] **Newest tier** — the last N entries per the policy. Never touched.
 - [ ] **Mid-age tier** — entries between newest and oldest. Light summarization only.
 - [ ] **Oldest tier** — everything older. Target for heavy compaction.
+
+> **Deterministic boundary:** the newest tier is the last N entries named in the policy.
+> The oldest tier is everything below the newest tier, down to **30% of the file's total
+> line count** (rounded to whole entries). Anything between is the mid-age tier. This keeps
+> compaction results consistent across sessions.
 
 ### Step 3: Compact the Oldest Tier
 

--- a/Feature/Memory-Compaction-System/install-memory-compaction.md
+++ b/Feature/Memory-Compaction-System/install-memory-compaction.md
@@ -98,7 +98,7 @@ No file is over budget. Compaction will run automatically when one is.
 | `compact memory` | Force a compaction pass on all over-budget files |
 | `compact [file]` | Compact a specific file now |
 | `check budgets` | Report each file's size against its budget |
-| `set budget [file] [n] lines` | Update a budget in the policy |
+| `set budget [file] [n] lines` or `set budget [file] [n] chars` | Update a budget in the policy |
 | `restore compaction [snapshot]` | Roll a file back to a pre-compaction snapshot |
 | `save` | Auto-checks budget first; compacts if needed, then saves |
 

--- a/Feature/Memory-Compaction-System/install-memory-compaction.md
+++ b/Feature/Memory-Compaction-System/install-memory-compaction.md
@@ -1,0 +1,135 @@
+# Install Memory Compaction System
+*Integration protocol for budget-aware memory compression*
+
+## Activation
+
+When the user says `Load memory-compaction`, install the Memory Compaction System into the active MemoryCore.
+
+## Prerequisites
+
+- Existing MemoryCore root with `master-memory.md`
+- Optional but recommended: Skill Plugin System
+- Optional companion features: Memory Consolidation System, Topic Diary System
+
+## Installation Steps
+
+### Step 1: Confirm MemoryCore Root
+
+Locate the active MemoryCore root. It should contain:
+
+```text
+master-memory.md
+main/
+```
+
+If the user's MemoryCore uses customized folder names, ask for confirmation before writing files.
+
+### Step 2: Create Compaction Directories
+
+Create these directories if missing:
+
+```text
+compaction/
+compaction/snapshots/
+```
+
+Never delete or overwrite existing snapshots.
+
+### Step 3: Create the Compaction Policy
+
+If `compaction/compaction-policy.md` does not exist, create it using `policy-format.md`.
+
+Default budgets (the user can adjust):
+
+```markdown
+| File | Budget | Newest tier (verbatim) |
+|------|--------|------------------------|
+| main/main-memory.md | 500 lines | last 20 entries |
+| main/relationship-memory.md | 400 lines | last 15 entries |
+| topic-diary/topics/*.md | 300 lines each | last 10 entries |
+```
+
+If the policy file exists, append a short installation note instead of replacing it.
+
+### Step 4: Add Master Memory References
+
+Update `master-memory.md` with:
+
+```markdown
+### Memory Compaction System
+*Runs automatically before "save" when a target memory file exceeds its budget.*
+- Budgets defined in `compaction/compaction-policy.md`
+- Snapshots written to `compaction/snapshots/` before any rewrite
+- Compresses oldest entries into a `## Compacted History` block (knowledge preserved)
+```
+
+Also add the budget-check behavior:
+
+```markdown
+Before writing a "save", check the target file against compaction/compaction-policy.md.
+If it exceeds budget, run the compaction protocol (snapshot, compact oldest tier, then save).
+```
+
+### Step 5: Install Skill Plugin
+
+If Skill Plugin System is installed:
+
+1. Copy `SKILL.md` into the configured skills/plugin folder as `memory-compaction/SKILL.md`
+2. Preserve existing skill files
+3. Confirm the trigger phrases are available
+
+If no Skill Plugin System is installed, leave the feature folder in place and record the manual commands in `master-memory.md`.
+
+### Step 6: Dry-Run Check
+
+Do **not** compact anything during installation. Instead, report current status:
+
+```text
+Memory Compaction installed. Current budgets:
+- main-memory.md: 312/500 lines (OK)
+- relationship-memory.md: 188/400 lines (OK)
+No file is over budget. Compaction will run automatically when one is.
+```
+
+## Commands After Installation
+
+| Command | Behavior |
+|---------|----------|
+| `compact memory` | Force a compaction pass on all over-budget files |
+| `compact [file]` | Compact a specific file now |
+| `check budgets` | Report each file's size against its budget |
+| `set budget [file] [n] lines` | Update a budget in the policy |
+| `restore compaction [snapshot]` | Roll a file back to a pre-compaction snapshot |
+| `save` | Auto-checks budget first; compacts if needed, then saves |
+
+## The Compaction Protocol
+
+When a file exceeds its budget:
+
+1. **Snapshot** — copy the current file to `compaction/snapshots/[file]-[date].md`
+2. **Split into tiers** — newest (verbatim), mid-age (light summary), oldest (heavy compaction)
+3. **Summarize the oldest tier** — distill into a dense block: keep facts, decisions, preferences; drop redundancy and chatter
+4. **Rewrite** — replace the verbose oldest entries with a `## Compacted History` block
+5. **Verify** — confirm the file is now under budget and no facts were lost
+6. **Report** — tell the user what was compacted and the new size
+
+## Safety Rules
+
+1. **Snapshot first** — never rewrite without a backup in `compaction/snapshots/`
+2. **Never compact the newest tier** — recent context must stay verbatim
+3. **Preserve facts, decisions, preferences** — only redundancy is dropped
+4. **Never summarize secrets** — exclude tokens, passwords, credentials from compaction blocks
+5. **Confirm before first compaction** of a user-customized file
+6. **Do not self-delete** this feature folder unless the user explicitly requests cleanup
+
+## Uninstall
+
+To uninstall manually:
+
+1. Remove Memory Compaction references from `master-memory.md`
+2. Remove the installed `memory-compaction` skill from the plugin folder
+3. Keep `compaction/snapshots/` unless the user explicitly wants to delete backups
+
+---
+
+*Install once; compaction runs only when a file actually needs it.*

--- a/Feature/Memory-Compaction-System/policy-format.md
+++ b/Feature/Memory-Compaction-System/policy-format.md
@@ -1,0 +1,66 @@
+# Compaction Policy Format
+*Canonical format for `compaction/compaction-policy.md`*
+
+Use this format to define which files are compacted, their budgets, and how much stays verbatim.
+
+## File Template
+
+```markdown
+# Compaction Policy
+*Budgets and retention tiers for memory compaction.*
+
+## Active Budgets
+
+| File | Budget | Newest Tier (verbatim) | Notes |
+|------|--------|------------------------|-------|
+| main/main-memory.md | 500 lines | last 20 entries | core identity + user profile |
+| main/relationship-memory.md | 400 lines | last 15 entries | user preferences |
+| topic-diary/topics/*.md | 300 lines each | last 10 entries | per-topic journals |
+
+## Retention Tiers
+
+- **Newest tier** — kept verbatim, never compacted.
+- **Mid-age tier** — light summarization (merge near-duplicate lines, trim filler).
+- **Oldest tier** — heavy compaction into a single `## Compacted History` block.
+
+## Compaction Triggers
+
+- Before any `save` that targets a budgeted file.
+- On the explicit `compact memory` command.
+- Never automatically on files not listed in this policy.
+
+## Exclusions
+
+- Never compact files under `compaction/snapshots/`.
+- Never compact secrets, tokens, passwords, or credentials.
+- Never compact the newest tier.
+
+## Maintenance Notes
+
+- Budgets are line-based by default; character-based budgets are allowed (e.g. `8000 chars`).
+- Adjust budgets to fit your model's context window.
+- Lower the budget for files you want kept very tight; raise it for reference-heavy files.
+```
+
+## Policy Guidelines
+
+- Keep one row per budgeted file (globs like `topics/*.md` are allowed).
+- Express budgets in `lines` or `chars` — pick one unit per file and state it.
+- The newest tier should always be large enough to hold active working context.
+- If a file is not in the policy table, it is **never** compacted.
+
+## Good Policy Example
+
+```markdown
+## Active Budgets
+
+| File | Budget | Newest Tier (verbatim) | Notes |
+|------|--------|------------------------|-------|
+| main/main-memory.md | 450 lines | last 25 entries | keep identity dense |
+| topic-diary/topics/docker.md | 250 lines | last 8 entries | high-churn topic |
+| topic-diary/topics/9router.md | 200 lines | last 8 entries | troubleshooting log |
+```
+
+---
+
+*The policy is the contract; compaction only does what the policy allows.*

--- a/Feature/Memory-Compaction-System/policy-format.md
+++ b/Feature/Memory-Compaction-System/policy-format.md
@@ -35,6 +35,18 @@ Use this format to define which files are compacted, their budgets, and how much
 - Never compact secrets, tokens, passwords, or credentials.
 - Never compact the newest tier.
 
+### Detecting Secrets
+
+Treat an entry as a secret (and exclude it from any `## Compacted History` block) if it matches
+any of these:
+
+- Key names ending in `_KEY`, `_TOKEN`, `_SECRET`, `_PASSWORD`, or `_CREDENTIAL`
+- High-entropy values that look like API keys, tokens, or private keys
+- Anything under a `## Secrets`, `## Credentials`, or `## Tokens` section header
+
+When a secret is found in the oldest tier, leave it verbatim in place (do not summarize it) or
+ask the user how to handle it. Never merge a secret value into a shared summary.
+
 ## Maintenance Notes
 
 - Budgets are line-based by default; character-based budgets are allowed (e.g. `8000 chars`).
@@ -58,7 +70,7 @@ Use this format to define which files are compacted, their budgets, and how much
 |------|--------|------------------------|-------|
 | main/main-memory.md | 450 lines | last 25 entries | keep identity dense |
 | topic-diary/topics/docker.md | 250 lines | last 8 entries | high-churn topic |
-| topic-diary/topics/9router.md | 200 lines | last 8 entries | troubleshooting log |
+| topic-diary/topics/9router.md | 6000 chars | last 10 entries | char-based budget for notes-heavy topic |
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Features are organized into **tiers** based on dependencies. Install Tier 1 firs
 |---------|-------------|-------|
 | 📖 [Save Diary](Feature/Save-Diary-System/) | Daily session documentation with monthly auto-archival | `"Load save-diary"` |
 | 🗂️ [Topic Diary](Feature/Topic-Diary-System/) | Topic-based memory journals for discoveries, fixes, and lessons across sessions — *pairs well with Save Diary + Echo Recall* | `"Load topic-diary"` |
+| 🗜️ [Memory Compaction](Feature/Memory-Compaction-System/) | Budget-aware compression — summarizes old entries into a dense history block instead of deleting them, with reversible snapshots — *complements Memory Consolidation* | `"Load memory-compaction"` |
 | 🔍 [Echo Memory Recall](Feature/Echo-Memory-Recall/) | Search past sessions with narrative context — *requires Save Diary* | `"Load echo-recall"` |
 | 🔔 [Reminders](Feature/Reminders-System/) | Persistent cross-session reminders with deadline tracking | `"Load reminders"` |
 | 📋 [Decision Log](Feature/Decision-Log-System/) | Append-only record of decisions and their reasoning | `"Load decision-log"` |


### PR DESCRIPTION
## What This Adds

A new **Memory Compaction System** feature — a budget-aware compression layer that keeps long-lived memory files within a size budget by **summarizing the oldest entries into a dense history block instead of deleting them**.

## Why

The existing memory features handle growth in two ways:
- **Memory Consolidation** merges split files into one (a one-time structural upgrade).
- **Session Memory Limit** caps session RAM with a hard reset that discards detail.

Neither handles the case where a *long-lived* file (main memory, relationship memory, a topic diary) slowly grows past the context budget. Truncation loses knowledge permanently. Compaction instead **distills old entries** — preserving facts, decisions, and preferences while dropping redundancy — and writes a reversible snapshot before any rewrite.

It's designed as a **companion** to the existing features, not a replacement, with a comparison table in the README to make the boundaries clear.

## Files

- `Feature/Memory-Compaction-System/README.md` — overview, comparison table, directory structure
- `Feature/Memory-Compaction-System/install-memory-compaction.md` — 6-step integration protocol + commands
- `Feature/Memory-Compaction-System/policy-format.md` — canonical `compaction-policy.md` format
- `Feature/Memory-Compaction-System/SKILL.md` — auto-triggered skill with a snapshot-first compaction protocol
- Registered in the root README Tier 2 table

## Design Notes

- **Snapshot before every compaction** — fully reversible via `compaction/snapshots/`.
- **Newest tier stays verbatim** — only old, low-signal entries are compacted.
- **Never compacts secrets** — tokens/passwords/credentials are excluded from summaries.
- Follows the existing feature folder convention (README + install + format + SKILL).

Tested the structure against the existing features for consistency. Happy to adjust naming or tier defaults to match your preferences.